### PR TITLE
[FEATURE]: Add refresh support for snapshot, filesystem_snapshot, volu…

### DIFF
--- a/plugins/doc_fragments/unity.py
+++ b/plugins/doc_fragments/unity.py
@@ -46,7 +46,7 @@ class ModuleDocFragment(object):
       - A Dell Unity Storage device version 5.1 or later.
       - Ansible-core 2.12 or later.
       - Python 3.9, 3.10 or 3.11.
-      - Storops Python SDK 1.2.11.
+      - Storops Python SDK > 1.2.11.
     notes:
       - The modules present in this collection named as 'dellemc.unity'
         are built to support the Dell Unity storage platform.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 urllib3
-storops>=1.2.11
+storops>1.2.11
 setuptools

--- a/tests/unit/plugins/module_utils/mock_consistencygroup_api.py
+++ b/tests/unit/plugins/module_utils/mock_consistencygroup_api.py
@@ -30,6 +30,10 @@ class MockConsistenyGroupApi:
         'mapping_state': None,
         'replication_params': {},
         'replication_state': None,
+        'retention_duration': None,
+        'copy_name': None,
+        'force_refresh': False,
+        'snapshot_name': None,
         'state': None
     }
     IP_ADDRESS_MOCK_VALUE = '***.***.***.**'
@@ -68,6 +72,41 @@ class MockConsistenyGroupApi:
                               'snaps_size_allocated': 0, 'snaps_size_total': 0, 'thin_status': 'ThinStatusEnum.TRUE',
                               'type': 'StorageResourceTypeEnum.CONSISTENCY_GROUP', 'virtual_volumes': None, 'vmware_uuid': None,
                               'existed': True, 'snapshots': [], 'cg_replication_enabled': False})
+
+    @staticmethod
+    def cg_get_refreshable_details_method_response():
+        return {'advanced_dedup_status': 'DedupStatusEnum.DISABLED', 'block_host_access': None, 'data_reduction_percent': 0,
+                'data_reduction_ratio': 1.0, 'data_reduction_size_saved': 0, 'data_reduction_status': 'DataReductionStatusEnum.DISABLED',
+                'datastores': None, 'dedup_status': None, 'description': '', 'esx_filesystem_block_size': None,
+                'esx_filesystem_major_version': None, 'filesystem': None, 'health': {}, 'host_v_vol_datastore': None,
+                'id': 'cg_id_2', 'is_replication_destination': False, 'is_snap_schedule_paused': None,
+                'luns': [{'id': 'lun_id_2', 'name': 'test_lun_cg_issue_clone', 'is_thin_enabled': False,
+                          'size_total': 1, 'is_data_reduction_enabled': False}],
+                'name': 'lun_test_cg_clone', 'per_tier_size_used': [1, 0, 0],
+                'pools': [{'id': 'pool_id_1'}],
+                'relocation_policy': 'TieringPolicyEnum.AUTOTIER_HIGH', 'replication_type': 'ReplicationTypeEnum.NONE',
+                'size_allocated': 0, 'size_total': 1, 'size_used': None, 'snap_count': 0, 'snap_schedule': None,
+                'snaps_size_allocated': 0, 'snaps_size_total': 0, 'thin_status': 'ThinStatusEnum.TRUE',
+                'type': 'StorageResourceTypeEnum.CONSISTENCY_GROUP', 'virtual_volumes': None, 'vmware_uuid': None,
+                'existed': True, 'snapshots': [], 'cg_replication_enabled': False, 'is_thin_clone': True}
+
+    @staticmethod
+    def get_refreshable_cg_object():
+        return MockSDKObject({'advanced_dedup_status': 'DedupStatusEnum.DISABLED', 'block_host_access': None,
+                              'data_reduction_percent': 0, 'data_reduction_ratio': 1.0, 'data_reduction_size_saved': 0,
+                              'data_reduction_status': 'DataReductionStatusEnum.DISABLED',
+                              'datastores': None, 'dedup_status': None, 'description': '', 'esx_filesystem_block_size': None,
+                              'esx_filesystem_major_version': None, 'filesystem': None, 'health': {}, 'host_v_vol_datastore': None,
+                              'id': 'cg_id_2', 'is_replication_destination': False, 'is_snap_schedule_paused': None,
+                              'luns': [MockSDKObject({'id': 'lun_id_2', 'name': 'test_lun_cg_issue_clone',
+                                                      'is_thin_enabled': False, 'size_total': 1, 'is_data_reduction_enabled': False})],
+                              'name': 'lun_test_cg_clone', 'per_tier_size_used': [1, 0, 0],
+                              'pools': [MockSDKObject({'id': 'pool_id_1'})],
+                              'relocation_policy': 'TieringPolicyEnum.AUTOTIER_HIGH', 'replication_type': 'ReplicationTypeEnum.NONE',
+                              'size_allocated': 0, 'size_total': 1, 'size_used': None, 'snap_count': 0, 'snap_schedule': None,
+                              'snaps_size_allocated': 0, 'snaps_size_total': 0, 'thin_status': 'ThinStatusEnum.TRUE',
+                              'type': 'StorageResourceTypeEnum.CONSISTENCY_GROUP', 'virtual_volumes': None, 'vmware_uuid': None,
+                              'existed': True, 'snapshots': [], 'cg_replication_enabled': False, 'is_thin_clone': True})
 
     @staticmethod
     def get_cg_replication_dependent_response(response_type):
@@ -120,3 +159,12 @@ class MockConsistenyGroupApi:
         conn = MockConsistenyGroupApi.get_cg_replication_dependent_response("remote_system")[0]
         conn.get_pool = MagicMock(return_value=MockConsistenyGroupApi.get_cg_replication_dependent_response('remote_system_pool_object'))
         return conn
+
+    @staticmethod
+    def refresh_cg_response(response_type):
+        if response_type == 'api':
+            return {'copy': {
+                    'id': "85899345930"
+                    }}
+        else:
+            return 'Failed to refresh thin clone [name: lun_test_cg_clone, id: cg_id_2] with error'

--- a/tests/unit/plugins/module_utils/mock_volume_api.py
+++ b/tests/unit/plugins/module_utils/mock_volume_api.py
@@ -36,6 +36,10 @@ class MockVolumeApi:
         'mapping_state': None,
         'new_vol_name': None,
         'tiering_policy': None,
+        'retention_duration': None,
+        'copy_name': None,
+        'force_refresh': False,
+        'snapshot_name': None,
         'state': None,
     }
 
@@ -172,3 +176,61 @@ class MockVolumeApi:
                     }}
         else:
             return 'Failed to modify the volume Atest with error'
+
+    @staticmethod
+    def refreshable_volume_response(response_type):
+        if response_type == 'api':
+            return {'volume_details': {
+                    'current_node': 'NodeEnum.SPB',
+                    'data_reduction_percent': 0,
+                    'data_reduction_ratio': 1.0,
+                    'data_reduction_size_saved': 0,
+                    'default_node': 'NodeEnum.SPB',
+                    'description': None,
+                    'effective_io_limit_max_iops': None,
+                    'effective_io_limit_max_kbps': None,
+                    'existed': True,
+                    'family_base_lun': {'UnityLun': {'id': 'sv_1613'}},
+                    'family_clone_count': 0,
+                    'hash': 8769317548849,
+                    'health': {'UnityHealth': {}},
+                    'host_access': [],
+                    'id': 'sv_214551',
+                    'io_limit_policy': None,
+                    'is_advanced_dedup_enabled': False,
+                    'is_compression_enabled': True,
+                    'is_data_reduction_enabled': True,
+                    'is_replication_destination': False,
+                    'is_snap_schedule_paused': False,
+                    'is_thin_clone': True,
+                    'is_thin_enabled': True,
+                    'metadata_size': 3758096384,
+                    'metadata_size_allocated': 3221225472,
+                    'name': 'Atest',
+                    'per_tier_size_used': [3489660928, 0, 0],
+                    'pool': {'id': 'pool_3', 'name': 'Extreme_Perf_tier'},
+                    'size_allocated': 0,
+                    'size_total': 2147483648,
+                    'size_total_with_unit': '2.0 GB',
+                    'size_used': None,
+                    'snap_count': 0,
+                    'snap_schedule': None,
+                    'snap_wwn': '60:06:01:60:5C:F0:50:00:F6:42:70:38:7A:90:40:FF',
+                    'snaps_size': 0,
+                    'snaps_size_allocated': 0,
+                    'storage_resource': {'UnityStorageResource': {'id': 'sv_1678', 'type': 8}},
+                    'tiering_policy': 'TieringPolicyEnum.AUTOTIER_HIGH',
+                    'type': 'LUNTypeEnum.STANDALONE',
+                    'wwn': '60:06:01:60:5C:F0:50:00:41:25:EA:63:94:92:92:AE',
+                    }}
+        else:
+            return None
+
+    @staticmethod
+    def refresh_volume_response(response_type):
+        if response_type == 'api':
+            return {'copy': {
+                    'id': "85899345930"
+                    }}
+        else:
+            return 'Failed to refresh thin clone [name: Atest, id: sv_214551] with error'


### PR DESCRIPTION

# Description
I've added refreshed state for snapshot, filesystem_snapshot, volume, and consistency_group to provide refresh capability for snapshots and thin clones.
A pending pull request for storops (https://github.com/emc-openstack/storops/pull/375) needs merging and releasing before this PR accepted.
Please review the modifications and feel free to ask if you have any questions.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #35  |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [x] I have performed Ansible Sanity test using --docker default
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Sanity Tests
- [x] Unit Tests
- [x] Functional Tests
