### PR TITLE
[fix] volume io_limit_policy.name fix

### DIFF
--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -970,7 +970,7 @@ class Volume(object):
                                        'id': obj_vol.snap_schedule.id}})
             if obj_vol.io_limit_policy:
                 volume_details.update(
-                    {'io_limit_policy': {'name': obj_vol.io_limit_policy.id,
+                    {'io_limit_policy': {'name': obj_vol.io_limit_policy.name,
                                          'id': obj_vol.io_limit_policy.id}})
             if obj_vol.pool:
                 volume_details.update({'pool': {'name': obj_vol.pool.name,


### PR DESCRIPTION
obj_vol.io_limit_policy.name was set to id instead of name

# Description
A few sentences describing the overall goals of the pull request's commits.

Details in [BUG]: In volume details, io_limit_policy dictionary in key 'name' is holding 'id' value. #43

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #43|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [ ] I have performed Ansible Sanity test using --docker default
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
