### PR TITLE
Ansible Galaxy yaml change

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -28,6 +28,7 @@ authors:
   - Spandita Panigrahi <ansible.team@dell.com>
   - Ananthu S Kuttattu <ansible.team@dell.com>
   - Pavan Mudunuri <ansible.team@dell.com>
+  - Shrinidhi Rao K Katte <ansible.team@dell.com>
 
 ### OPTIONAL but strongly recommended
 # A short summary description of the collection
@@ -72,3 +73,9 @@ issues: https://www.dell.com/community/Automation/bd-p/Automation
 # files like 'galaxy.yml', '*.pyc', '*.retry', and '.git' are always filtered
 build_ignore:
   - codecov.yml
+  - .venv*
+  - .ansible-lint
+  - .github
+  - .gitignore
+  - catalog-info.yaml
+  - .pytest_cache


### PR DESCRIPTION
- Add build_ignore entries for .venv*, .ansible-lint, .github, .gitignore, catalog-info.yaml, .pytest_cache
- Add Shrinidhi Rao K Katte as author
- Ensures cleaner collection tar.gz package

Task: Unity Galaxy Update
JIRA: ECS02C-973, ECS02C-1092

# Description
A few sentences describing the overall goals of the pull request's commits.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [ ] I have performed Ansible Sanity test using --docker default
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
